### PR TITLE
Feature: Literal values

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Deno - Debian bookworm",
-	"image": "denoland/deno:debian-2.5.4",
+	"image": "denoland/deno:debian-2.7.12",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/deno.json
+++ b/deno.json
@@ -17,6 +17,6 @@
   },
   "license": "MIT",
   "imports": {
-    "@std/assert": "jsr:@std/assert@1"
+    "@std/assert": "jsr:@std/assert@^1.0.19"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,23 +1,23 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.11",
-    "jsr:@std/internal@^1.0.5": "1.0.5"
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.12"
   },
   "jsr": {
-    "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
     },
-    "@std/internal@1.0.5": {
-      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     }
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@1"
+      "jsr:@std/assert@^1.0.19"
     ]
   }
 }

--- a/lib/binary-filter-expression.ts
+++ b/lib/binary-filter-expression.ts
@@ -1,3 +1,4 @@
+import { bake as bakeLiterals } from "./literal.ts";
 import type { BooleanNumber } from "./types.ts";
 
 /**
@@ -98,10 +99,11 @@ function acceptableValue(operator: Operator, value: unknown): boolean {
  * A Template Literal to build a {@linkcode BinaryFilterExpression}.
  */
 export function parse(
-	[expression, ...strings]: TemplateStringsArray,
-	value: unknown,
-	...values: unknown[]
+	originalStrings: TemplateStringsArray,
+	...originalValues: unknown[]
 ): BinaryFilterExpression {
+	const [[expression, ...strings], [value, ...values]] = bakeLiterals(originalStrings, ...originalValues);
+
 	if (expression.length > 2 && strings.length === 1 && values.length === 0) {
 		const { key, not, operator }: Partial<RegExpExecArray["groups"]> = EXPRESSION_RE.exec(expression)?.groups ??
 			{};

--- a/lib/binary-filter-expression_test.ts
+++ b/lib/binary-filter-expression_test.ts
@@ -167,7 +167,7 @@ Deno.test(function testInvalidValue_bt() {
 });
 
 Deno.test(function testExpressionWithLiteralOperator() {
-	const eq = literal('eq');
+	const eq = literal("eq");
 	const value = 42;
 	const expression = E`meaning ${eq} ${value}`;
 

--- a/lib/binary-filter-expression_test.ts
+++ b/lib/binary-filter-expression_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertObjectMatch, assertThrows } from "@std/assert";
 import { parse as E } from "./binary-filter-expression.ts";
+import { literal } from "./literal.ts";
 
 Deno.test(function invalidOperatorTest() {
 	assertThrows(() => E`witnessed yt ${"yes"}`);
@@ -163,4 +164,17 @@ Deno.test(function testInvalidValue_bt() {
 		() => E`x bt ${arrayLike}`,
 		`The "bt" operator requires an array-like value containing exactly two constants`,
 	);
+});
+
+Deno.test(function testExpressionWithLiteralOperator() {
+	const eq = literal('eq');
+	const value = 42;
+	const expression = E`meaning ${eq} ${value}`;
+
+	assertObjectMatch(expression, {
+		key: "meaning",
+		operator: "eq",
+		value: 42,
+		not: 0,
+	});
 });

--- a/lib/caelum-revelat.ts
+++ b/lib/caelum-revelat.ts
@@ -40,6 +40,8 @@ export {
 	parse as E,
 } from "./binary-filter-expression.ts";
 
+export { literal, parse as L } from "./literal.ts";
+
 export { type FilterGroup, isFilterGroup, parse as G } from "./logical-group-expression.ts";
 
 /**

--- a/lib/literal.ts
+++ b/lib/literal.ts
@@ -64,6 +64,11 @@ export function parse(strings: TemplateStringsArray, ...values: unknown[]): Lite
 	return literal(value);
 }
 
+/**
+ * Bake literal values into the strings array.
+ *
+ * Internal "middleware" for the expression template string literals.
+ */
 export function bake(strings: TemplateStringsArray, ...values: unknown[]): [string[], unknown[]] {
 	const baked: string[] = [];
 	const outValues: unknown[] = [];

--- a/lib/literal.ts
+++ b/lib/literal.ts
@@ -1,0 +1,89 @@
+/**
+ * The symbol used to mark the Literal container type.
+ */
+const Literal = Symbol("Literal");
+
+/**
+ * Literal container. Will be unwrapped internally.
+ */
+export type Literal = {
+	value: string;
+	[Literal]: true;
+};
+
+/**
+ * Wrap a string value into a `Literal`.
+ *
+ * @throws {TypeError} when an empty string (or all whitespace) is given.
+ */
+export function literal(value: string): Literal {
+	if (isLiteral(value as unknown)) {
+		throw new Error("Nested literal values are not supported");
+	}
+
+	if (!value.trim()) {
+		throw new TypeError("Cannot create empty literal");
+	}
+
+	return Object.create(null, {
+		value: {
+			configurable: false,
+			enumerable: true,
+			value,
+			writable: false,
+		},
+		[Literal]: {
+			configurable: false,
+			enumerable: false,
+			value: true,
+			writable: false,
+		},
+	});
+}
+
+/**
+ * Type guard to test if a value is `Literal`.
+ */
+export function isLiteral(value: unknown): value is Literal {
+	return typeof value === "object" && value !== null && Object.hasOwn(value, Literal);
+}
+
+/**
+ * Get the string value contained by the given `Literal`.
+ */
+export function unwrap(literal: Literal): string {
+	return literal.value;
+}
+
+/**
+ * Parse a template literal string as a `Literal`.
+ */
+export function parse(strings: TemplateStringsArray, ...values: unknown[]): Literal {
+	const value = String.raw({ raw: strings }, ...values);
+
+	return literal(value);
+}
+
+export function bake(strings: TemplateStringsArray, ...values: unknown[]): [string[], unknown[]] {
+	const baked: string[] = [];
+	const outValues: unknown[] = [];
+
+	let current = strings[0];
+
+	for (let i = 0; i < values.length; i++) {
+		const value = values[i];
+		const next = strings[i + 1];
+
+		if (isLiteral(value)) {
+			current += unwrap(value) + next;
+		} else {
+			baked.push(current);
+			outValues.push(value);
+			current = next;
+		}
+	}
+
+	baked.push(current);
+
+	return [baked, outValues];
+}

--- a/lib/literal_test.ts
+++ b/lib/literal_test.ts
@@ -1,0 +1,116 @@
+import {
+	assert,
+	assertArrayIncludes,
+	assertEquals,
+	assertExists,
+	assertFalse,
+	assertNotEquals,
+	assertObjectMatch,
+	assertThrows,
+} from "@std/assert";
+import { bake, isLiteral, literal, parse, unwrap } from "./literal.ts";
+
+Deno.test(async function LiteralTests(t) {
+	await t.step(function testCreateLiteral() {
+		const value = "value";
+		const l = literal(value);
+
+		assert(Object.hasOwn(l, "value"));
+		assertEquals(Object.getOwnPropertyNames(l).length, 1);
+		assertEquals(Object.getOwnPropertySymbols(l).length, 1);
+		assertExists(l);
+		assertObjectMatch(l, {
+			value,
+		});
+
+		assertThrows(() => literal(""), TypeError, "Cannot create empty literal");
+		assertThrows(() => literal(" "), TypeError, "Cannot create empty literal");
+		assertThrows(() => literal("\t"), TypeError, "Cannot create empty literal");
+		assertThrows(() => literal("\n"), TypeError, "Cannot create empty literal");
+		assertThrows(() => literal("  \t\n  "), TypeError, "Cannot create empty literal");
+	});
+
+	await t.step(function testIsLiteral() {
+		assertFalse(isLiteral("value"));
+		assertFalse(isLiteral(""));
+		assertFalse(isLiteral(null));
+		assertFalse(isLiteral(undefined));
+		assertFalse(isLiteral(1));
+		assertFalse(isLiteral(true));
+		assertFalse(isLiteral(false));
+		assertFalse(isLiteral({}));
+		assertFalse(isLiteral({ value: "eq" }));
+		assert(isLiteral(literal("eq")));
+		assert(isLiteral(literal("first_name")));
+	});
+
+	await t.step(function testPreventNestedLiteral() {
+		const inner = literal("inner");
+
+		// Nested literals can only happen without typescript guards. Needs to be prevented for pure javascript usage.
+		assertThrows(() => literal(inner as unknown as string), Error, "Nested literal values are not supported");
+	});
+
+	await t.step(function testParse() {
+		const l = parse`lte`;
+
+		assertObjectMatch(l, {
+			value: "lte",
+		});
+		assertEquals(l, literal("lte"));
+		assertNotEquals(l, literal("gt"));
+	});
+
+	await t.step(function testBakeOneString() {
+		const [strings, values] = bake`s`;
+
+		assertEquals(strings.length, 1);
+		assertArrayIncludes(strings, ["s"]);
+		assertEquals(values.length, 0);
+	});
+
+	await t.step(function testBakeOneValue() {
+		const [strings, values] = bake`first_name eq ${"billy"}`;
+
+		assertEquals(strings.length, 2);
+		assertArrayIncludes(strings, ["first_name eq ", ""]);
+		assertEquals(values.length, 1);
+		assertArrayIncludes(values, ["billy"]);
+	});
+
+	await t.step(function testBakeOneLiteral() {
+		const [strings, values] = bake`${literal("last_name")} eq ${"williams"}`;
+
+		assertEquals(strings.length, 2);
+		assertArrayIncludes(strings, ["last_name eq ", ""]);
+		assertEquals(values.length, 1);
+		assertArrayIncludes(values, ["williams"]);
+	});
+
+	await t.step(function testBakeTwoLiterals() {
+		const [strings, values] = bake` ${literal("photo")} ${literal("not_eq")} ${null} `;
+
+		assertEquals(strings.length, 2);
+		assertArrayIncludes(strings, [" photo not_eq ", " "]);
+		assertEquals(values.length, 1);
+		assertArrayIncludes(values, [null]);
+	});
+
+	await t.step(function testBakeTwoLiteralsSansWhitespace() {
+		const [strings, values] = bake`${literal("age")}${literal(" eq ")}${5}`;
+
+		assertEquals(strings.length, 2);
+		assertArrayIncludes(strings, ["age eq ", ""]);
+		assertEquals(values.length, 1);
+		assertArrayIncludes(values, [5]);
+	});
+
+	await t.step(function testUnwrap() {
+		const not_eq = literal("not_eq");
+		const gt = literal("gt");
+
+		assertEquals(typeof unwrap(not_eq), "string");
+		assertEquals(unwrap(not_eq), "not_eq");
+		assertEquals(unwrap(gt), "gt");
+	});
+});

--- a/lib/logical-group-expression.ts
+++ b/lib/logical-group-expression.ts
@@ -1,4 +1,5 @@
 import { type BinaryFilterExpression, isBinaryFilterExpression } from "./binary-filter-expression.ts";
+import { bake as bakeLiterals } from "./literal.ts";
 import type { BooleanNumber } from "./types.ts";
 
 /**
@@ -19,7 +20,9 @@ export type FilterGroup = {
  * A Template Literal to build a FilterGroup. All interpolated values should
  * already be parsed as a {@linkcode BinaryFilterExpression}.
  */
-export function parse(strings: TemplateStringsArray, ...values: unknown[]): FilterGroup {
+export function parse(originalStrings: TemplateStringsArray, ...originalValues: unknown[]): FilterGroup {
+	const [strings, values] = bakeLiterals(originalStrings, ...originalValues);
+
 	if (values.length === 0) {
 		throw new Error("A filter group may not be empty");
 	}

--- a/lib/logical-group-expression_test.ts
+++ b/lib/logical-group-expression_test.ts
@@ -72,8 +72,8 @@ Deno.test(function createOrTest() {
 Deno.test(function createWithLiteralsTest() {
 	const operator = L`ct`;
 	const grouping = L`or`;
-	const search = 'jef'
-	const group = G`${ E`first_name ${operator} ${search}` } ${grouping} ${ E`last_name ${operator} ${search}` }`;
+	const search = "jef";
+	const group = G`${E`first_name ${operator} ${search}`} ${grouping} ${E`last_name ${operator} ${search}`}`;
 
 	assertObjectMatch(group, {
 		or: 1,

--- a/lib/logical-group-expression_test.ts
+++ b/lib/logical-group-expression_test.ts
@@ -1,6 +1,7 @@
 import { assertObjectMatch, assertThrows } from "@std/assert";
 import { parse as E } from "./binary-filter-expression.ts";
 import { parse as G } from "./logical-group-expression.ts";
+import { parse as L } from "./literal.ts";
 
 Deno.test(function invalidGroupWhenEmpty() {
 	assertThrows(() => G``);
@@ -62,6 +63,31 @@ Deno.test(function createOrTest() {
 				key: "month_age",
 				operator: "bt",
 				value: [252, 315],
+				not: 0,
+			},
+		],
+	});
+});
+
+Deno.test(function createWithLiteralsTest() {
+	const operator = L`ct`;
+	const grouping = L`or`;
+	const search = 'jef'
+	const group = G`${ E`first_name ${operator} ${search}` } ${grouping} ${ E`last_name ${operator} ${search}` }`;
+
+	assertObjectMatch(group, {
+		or: 1,
+		filters: [
+			{
+				key: "first_name",
+				operator: "ct",
+				value: "jef",
+				not: 0,
+			},
+			{
+				key: "last_name",
+				operator: "ct",
+				value: "jef",
 				not: 0,
 			},
 		],


### PR DESCRIPTION
## New API

#### Function: `literal(value: string): Literal`

Convert a static string value to a literal value.

```typescript
import { literal } from "@codeman99/caelum-revelat";

const operator = literal("eq");
```

#### `L` Template

To keep a familiar interface, a literal may also be created using a template string.

```typescript
import { L } from "@codeman99/caelum-revelat";

const column = L`release_year`;
```

## Updated API

The expression and group templates have been updated to accept literal values.

```typescript
import { E, L } from "@codeman99/caelum-revelat";

const eq = L`eq`
const value = 42;
const expression = E`meaning ${eq} ${value}`;
```

```typescript
import { E, G, L } from "@codeman99/caelum-revelat";

const and = L`and`;
const group = G`
   ${ E`zip_code eq ${83632}` }
   ${ and }
   ${ E`state eq ${"RI"}` }
`;
```